### PR TITLE
Compatibility with Ghidra 9.1

### DIFF
--- a/src/main/java/lx/LXLoader.java
+++ b/src/main/java/lx/LXLoader.java
@@ -21,7 +21,6 @@ import java.util.*;
 import ghidra.app.util.Option;
 import ghidra.app.util.bin.BinaryReader;
 import ghidra.app.util.bin.ByteProvider;
-import ghidra.app.util.importer.MemoryConflictHandler;
 import ghidra.app.util.importer.MessageLog;
 import ghidra.app.util.opinion.AbstractLibrarySupportLoader;
 import ghidra.app.util.opinion.LoadSpec;
@@ -52,7 +51,7 @@ public class LXLoader extends AbstractLibrarySupportLoader {
 	
 	@Override
 	protected void load(ByteProvider provider, LoadSpec loadSpec, List<Option> options,
-			Program program, MemoryConflictHandler handler, TaskMonitor monitor, MessageLog log)
+			Program program, TaskMonitor monitor, MessageLog log)
 			throws CancelledException, IOException {
 		LX lx;
 		long base_addr;


### PR DESCRIPTION
MemoryConflictHandler doesn't exist any more.