### PR TITLE
use default blocks instead of overlays

### DIFF
--- a/src/main/java/lx/LXLoader.java
+++ b/src/main/java/lx/LXLoader.java
@@ -79,7 +79,7 @@ public class LXLoader extends AbstractLibrarySupportLoader {
 			data = lx.readObjectData(reader, ohdr);
 			
 			try {
-				block = api.createMemoryBlock(name, api.toAddr(ohdr.reloc_base_addr), data, true);
+				block = api.createMemoryBlock(name, api.toAddr(ohdr.reloc_base_addr), data, false);
 				ohdr.setObjectPermissions(block);
 			} catch (Exception e) {
 				Msg.error(this, e.getMessage());


### PR DESCRIPTION
Overlay blocks are apparently not part of the default address space.

Before, my entrypoint would appear as EXT_00062178, but clicking on it gave "Can not navigate to Label symbol : EXT_00062178 (not in-memory)" and I wouldn't get any functions or disassembly. Additionally, after manually disassembling, none of the xrefs from code objects to data objects would resolve because "Address not found in program memory".

After, my entrypoint appears as thunk_FUN_000621f2, and I can navigate between code and data objects.