### PR TITLE
Add initial github workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,28 @@
+name: Build ghidra-lx-loader
+on:
+  pull_request:
+  push:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v1
+      - uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'zulu'
+      - name: Setup ghidra
+        uses: er28-0652/setup-ghidra@master
+        with:
+          version: '10.1'
+      - name: Build Ghidra extension (using gradle)
+        uses: gradle/gradle-build-action@v2
+        with:
+          gradle-version: 'current'
+          arguments: 'buildExtension'
+      - uses: actions/upload-artifact@v2
+        with:
+          name: ghidra-lx-loader
+          path: |
+            dist/*.zip


### PR DESCRIPTION
Using github workflows allows continuous integration + continuous delivery.
I created this workflow to easily create a new installable extension.

An example of a run can be found here: https://github.com/madebr/ghidra-lx-loader/actions/runs/1599455529

The only difference between a zip created by a github action and a release is:
- the filename of the zip: `ghidra_10.0.4_PUBLIC_20211012_LX.zip` vs `ghidra_10.1_PUBLIC_20211219_ghidra-lx-loader.zip`
- The zip now also contains a `.github` subfolder

I hope this pr can serve as a basis for improvements.
At the moment, I hard coded the ghidra version to 10.1.
This can be changed into a list of recent ghidra versions.