### PR TITLE
Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Mariusz Zaborski <oshogbo@FreeBSD.org>
 
 ## Verficattion
 
-I verfived output of the module vs IDA Freeware 4.1 and swars source code.
+I verified output of the module vs IDA Freeware 4.1 and swars source code.
 
 ## Resources
 

--- a/src/main/java/lx/LXObjectPageTable.java
+++ b/src/main/java/lx/LXObjectPageTable.java
@@ -22,13 +22,13 @@ import ghidra.app.util.bin.BinaryReader;
 
 /*
  * [Doc]
- * XXX: WTF???? This dosen't seem right. 
+ * XXX: WTF???? This doesn't seem right.
  *        63                     32 31       16 15         0
  *         +-----+-----+-----+-----+-----+-----+-----+-----+
  *     00h |    PAGE DATA OFFSET   | DATA SIZE |   FLAGS   |
  *         +-----+-----+-----+-----+-----+-----+-----+-----+
  * More reliable looks:
- * 		   32                     16           8           0
+ *        32                      16           8           0
  *         +-----+-----+-----+-----+-----+-----+-----+-----+
  *     00h |    PAGE DATA OFFSET   | DATA SIZE |   FLAGS   |
  *         +-----+-----+-----+-----+-----+-----+-----+-----+

--- a/src/main/java/lx/LXObjectTable.java
+++ b/src/main/java/lx/LXObjectTable.java
@@ -77,8 +77,8 @@ public class LXObjectTable {
 	
 	public void setObjectPermissions(MemoryBlock block) {
 		block.setRead(isReadable());
-    	block.setWrite(isWritable());
-    	block.setExecute(isExecutable());
+		block.setWrite(isWritable());
+		block.setExecute(isExecutable());
 	}
 	
 	public void appendFixupTable(LXFixupRecordTable fr) {


### PR DESCRIPTION
The `srcoff` field of a fixup table entry can be either 1 or 2 bytes, depending of the `Source List Flag`
```
     SRCOFF =  DW/CNT  = DB  Source  offset  or source offset 
     list count. 
         This field contains  either  an  offset  or  a count 
         depending on the  Source  List Flag.  If the  Source 
         List Flag is  set,  a list of source offsets follows 
         the additive field and this field contains the count 
         of  the  entries   in   the   source   offset  list. 
         Otherwise, this is the single source offset for  the 
         fixup.  Source offsets are relative to the beginning 
         of the page where the fixup is to be made. 
```


+ 2 bonus typo/layout fixes