### PR TITLE
CI: Avoid api rate limiting

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,6 +21,7 @@ jobs:
       - name: Setup ghidra
         uses: antoniovazquezblanco/setup-ghidra@v2.0.3
         with:
+          auth_token: ${{ secrets.GITHUB_TOKEN }}
           version: ${{ matrix.ghidra }}
       - name: Build Ghidra extension (using gradle)
         uses: gradle/gradle-build-action@v2


### PR DESCRIPTION
I was looking at the pipeline after the merge. The error you got is quite unusual. To avoid it you may use an auth token as in this PR or you may run the pipeline again in some time.

This seems to be happening because the same runner has been running many setup-ghidra actions today which is unfortunate.