### PR TITLE
Bump Github actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           version: ${{ matrix.ghidra }}
       - name: Build Ghidra extension (using gradle)
-        uses: gradle/gradle-build-action@v2
+        uses: gradle/gradle-build-action@v3
         with:
           gradle-version: 'current'
           arguments: 'buildExtension'


### PR DESCRIPTION
* Bump Github actions, this should remove warnings about deprecated nodejs from workflow runs

If you wish I can also create `.github/dependabot.yml` file to automate bump of these actions on daily/weekly/monthly basis