### PR TITLE
Add automatic GH actions bump

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    commit-message:
+      prefix: "actions"


### PR DESCRIPTION
- Add automatic monthly GH actions bump
    - each bumped action will open separate PR, but it can be configured to consolidate all updates into one PR, your call